### PR TITLE
fix command help message (#11 Issue)

### DIFF
--- a/cmd/product.go
+++ b/cmd/product.go
@@ -79,7 +79,7 @@ func init() {
 	// Update product
 	productCmd.AddCommand(productUpdateCmd)
 	productUpdateCmd.Flags().StringVar(&productDesc, "desc", "", "Specify description")
-	productUpdateCmd.Flags().BoolVar(&productEnabled, "enabled", false, "Enable produc")
+	productUpdateCmd.Flags().BoolVar(&productEnabled, "enabled", false, "Enable product (default false)")
 	productUpdateCmd.Flags().StringVar(&productSchemaFile, "schema", "", "Load schema from specific file")
 
 	// Delete and purge product

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -44,12 +44,12 @@ func init() {
 	// Create
 	tokenCmd.AddCommand(tokenCreateCmd)
 	tokenCreateCmd.Flags().StringVar(&tokenDesc, "desc", "", "Specify description")
-	tokenCreateCmd.Flags().BoolVar(&tokenEnabled, "enabled", true, "Enable token (default true)")
+	tokenCreateCmd.Flags().BoolVar(&tokenEnabled, "enabled", true, "Enable token")
 
 	// Update
 	tokenCmd.AddCommand(tokenUpdateCmd)
 	tokenUpdateCmd.Flags().StringVar(&tokenDesc, "desc", "", "Specify description")
-	tokenUpdateCmd.Flags().BoolVar(&tokenEnabled, "enabled", true, "Enable token (default true)")
+	tokenUpdateCmd.Flags().BoolVar(&tokenEnabled, "enabled", true, "Enable token")
 
 	// Grant
 	tokenCmd.AddCommand(tokenGrantCmd)


### PR DESCRIPTION
#11

### Changes
Issue 1: Duplicate (default true) in Command Usage for `token create` and `token update`

Remove the manually added (default true) from the flag description for both commands.

Issue 2: Incomplete description for `--enabled` in `product update`

Correct the description to "Enable product (default false)".
